### PR TITLE
Fix bug preventing the code generation to drop selected features.

### DIFF
--- a/flask_app/flask_main.py
+++ b/flask_app/flask_main.py
@@ -50,7 +50,7 @@ def split_data():
 @app.route('/input_labels', methods=['GET', 'POST'])
 def get_input_labels():
    if request.method == 'POST':
-      request_dict = request.form.to_dict()
+      request_dict = request.form.to_dict(flat=False)
       generator.drop_x(request_dict['drop_labels'])
       return render_template('actions/actions.html')
 

--- a/flask_app/templates/actions/select_input_values.html
+++ b/flask_app/templates/actions/select_input_values.html
@@ -11,7 +11,7 @@
    <form action="/input_labels" method="post">
       <div>
           {% for label in labels %}
-             <input type="checkbox" name="drop_labels" value= "{{label}}" SELECTED>{{label}}</option>"
+             <input type="checkbox" name="drop_labels" value="{{label}}">{{label}}</input>"
           {% endfor %}
       </div>
 

--- a/pandas_code/code_templates/drop_x.py
+++ b/pandas_code/code_templates/drop_x.py
@@ -1,4 +1,4 @@
-# split the data set into training and test data
+# drop dataset features passed to args param
 def get_code(args):
    x_values = args[0].drop(args[1], axis=1)
    return x_values


### PR DESCRIPTION
**What was changed?**
The feature drop form (`select_input_values.html`) and the related `get_input_labels()` method present in the `flask_main.py` file.

**Why was it changed?**
The features selected in the `select_input_values.html` was not being added to the generated code.

**How was it changed?**
The HTML form had a syntax error and inside the `get_input_labels()` method it was missing the `flat=False` param to be passed to the `to_dict` function to enable it in handling multiple selected checkboxes.

Result:
<img width="713" alt="Captura de Tela 2022-10-07 às 21 18 56" src="https://user-images.githubusercontent.com/3163733/194677941-c116a3a4-18ac-4fc9-9114-4e730552369b.png">
