### PR TITLE
feat: enable custom definition of the training data ratio

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/flask_app/flask_main.py
+++ b/flask_app/flask_main.py
@@ -50,7 +50,7 @@ def split_data():
 @app.route('/input_labels', methods=['GET', 'POST'])
 def get_input_labels():
    if request.method == 'POST':
-      request_dict = request.form.to_dict()
+      request_dict = request.form.to_dict(flat=False)
       generator.drop_x(request_dict['drop_labels'])
       return render_template('actions/actions.html')
 

--- a/flask_app/templates/actions/select_input_values.html
+++ b/flask_app/templates/actions/select_input_values.html
@@ -11,7 +11,7 @@
    <form action="/input_labels" method="post">
       <div>
           {% for label in labels %}
-             <input type="checkbox" name="drop_labels" value= "{{label}}" SELECTED>{{label}}</option>"
+             <input type="checkbox" name="drop_labels" value="{{label}}">{{label}}</input>"
           {% endfor %}
       </div>
 

--- a/pandas_code/code_templates/drop_x.py
+++ b/pandas_code/code_templates/drop_x.py
@@ -1,4 +1,4 @@
-# split the data set into training and test data
+# drop dataset features passed to args param
 def get_code(args):
    x_values = args[0].drop(args[1], axis=1)
    return x_values


### PR DESCRIPTION
**What was changed?**
The split feature now calls a form containing a slider to enable a user to customize the training data ratio. This feature was described in issue #10.

**Why was it changed?**
Previously, the split feature was using a default and static value of 80% to define the training data ratio. It was changed to allow the definition of a customized proportion (between training and test data).

**How was it changed?**
- A new HTML file (`select_training_ratio_value.html`) following the same architecture used by the application was added. This HTML file contains an HTML form with an interactive slider element (inspired by [the TensorFlow Playground](https://playground.tensorflow.org/)), which enables the user to define the training ratio.
- The `split_data()` present in the `flask_main.py` now handles two HTTP methods. The GET method returns the discussed form. The POST method is called when the form is submitted, passing the training ratio value to the underlying code generator.
- New CSS styles were added to design the form and to correct some layout bugs. Example:
![Captura de Tela 2022-10-09 às 00 16 24](https://user-images.githubusercontent.com/3163733/194737084-277362a5-7462-4cbf-8f0a-57c7504c901a.png)

**Result:**
![Captura de Tela 2022-10-09 às 00 53 16](https://user-images.githubusercontent.com/3163733/194737129-2d9b47ef-ee6b-4a3c-bcf3-699d90e00acf.png)
![Captura de Tela 2022-10-09 às 00 53 22](https://user-images.githubusercontent.com/3163733/194737130-aaeb5794-3663-46fe-82de-891924e32b8b.png)




