### PR TITLE
#54: Flask app centralized URL map

### DIFF
--- a/flask_app/api/config.py
+++ b/flask_app/api/config.py
@@ -1,0 +1,2 @@
+ALLOWED_EXTENSIONS = {'csv'}
+UPLOAD_FOLDER = 'data/'

--- a/flask_app/api/generator.py
+++ b/flask_app/api/generator.py
@@ -1,0 +1,6 @@
+from application import code_generator
+from pandas_code.mapping import template_mapping
+from pandas_code.parse_template import parse_template
+
+
+generator = code_generator.CodeGenerator(template_mapping, parse_template)

--- a/flask_app/api/utils.py
+++ b/flask_app/api/utils.py
@@ -2,4 +2,4 @@ from flask_app.api.config import ALLOWED_EXTENSIONS
 
 
 def allowed_file(filename):
-    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
+   return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS

--- a/flask_app/api/utils.py
+++ b/flask_app/api/utils.py
@@ -1,0 +1,5 @@
+from flask_app.api.config import ALLOWED_EXTENSIONS
+
+
+def allowed_file(filename):
+    return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS

--- a/flask_app/api/views.py
+++ b/flask_app/api/views.py
@@ -1,0 +1,86 @@
+import os
+
+from flask import g
+from flask import current_app
+from flask import render_template
+from flask import request, redirect, flash
+from werkzeug.utils import secure_filename
+
+from flask_app.api.generator import generator
+from flask_app.api.utils import allowed_file
+
+
+def welcome():
+    return render_template('home.html')
+
+def download_code():
+    code = generator.download_code()
+    return render_template('info/code.html', text=code)
+
+def describe_data():
+    description = generator.describe_data()
+    return render_template('info/description.html',table=description.to_html())
+
+def clean_data():
+    original_data_size = generator.get_data().shape
+    cleaned_data_size = generator.clean_data()
+    num_rows_removed = original_data_size[0]-cleaned_data_size[0]
+    return render_template('info/cleaning_summary.html', removed_rows=num_rows_removed)
+
+def split_data():
+    if request.method == 'POST':
+        request_dict = request.form.to_dict()
+        training_ratio = int(request_dict['trainingRatioRange'])/100
+        train_data_size = generator.split_data(training_ratio)
+        return render_template('info/splitting_summary.html', num_rows_train=train_data_size[0])
+
+    return render_template('actions/select_training_ratio_value.html')
+
+def get_input_labels():
+    if request.method == 'POST':
+        request_dict = request.form.to_dict(flat=False)
+        generator.drop_x(request_dict['drop_labels'])
+        return render_template('actions/actions.html')
+
+    keys = generator.get_labels()
+    return render_template('actions/select_input_values.html', labels=keys)
+
+def get_data_labels():
+    if request.method == 'POST':
+        request_dict = request.form.to_dict()
+        generator.select_y(request_dict['label'])
+        return redirect('/input_labels')
+
+    keys = generator.get_labels()
+    return render_template('actions/select_output_value.html', labels=keys)
+    # return render_template('labels.html', labels=keys)
+
+def upload_file():
+    if request.method == 'POST':
+        # check if the post request has the file part
+        if 'file' not in request.files:
+            flash('No file part')
+            return redirect(request.url)
+
+        file = request.files['file']
+        # If the user does not select a file, the browser submits an
+        # empty file without a filename.
+        if file.filename == '':
+            flash('No selected file')
+            return redirect(request.url)
+
+        if file and allowed_file(file.filename):
+            filename = secure_filename(file.filename)
+            file.save(os.path.join(current_app.config['UPLOAD_FOLDER'], filename))
+            # return redirect(url_for('download_file', name=filename))
+            print(g)
+
+            with current_app.app_context():
+                generator.load_data(current_app.config['UPLOAD_FOLDER']+'/' + filename)
+
+            return render_template('actions/actions.html')
+
+    return render_template('actions/upload_data.html')
+
+def next_actions():
+    return render_template('actions/actions.html')

--- a/flask_app/api/views.py
+++ b/flask_app/api/views.py
@@ -11,76 +11,76 @@ from flask_app.api.utils import allowed_file
 
 
 def welcome():
-    return render_template('home.html')
+   return render_template('home.html')
 
 def download_code():
-    code = generator.download_code()
-    return render_template('info/code.html', text=code)
+   code = generator.download_code()
+   return render_template('info/code.html', text=code)
 
 def describe_data():
-    description = generator.describe_data()
-    return render_template('info/description.html',table=description.to_html())
+   description = generator.describe_data()
+   return render_template('info/description.html', table=description.to_html())
 
 def clean_data():
-    original_data_size = generator.get_data().shape
-    cleaned_data_size = generator.clean_data()
-    num_rows_removed = original_data_size[0]-cleaned_data_size[0]
-    return render_template('info/cleaning_summary.html', removed_rows=num_rows_removed)
+   original_data_size = generator.get_data().shape
+   cleaned_data_size = generator.clean_data()
+   num_rows_removed = original_data_size[0]-cleaned_data_size[0]
+   return render_template('info/cleaning_summary.html', removed_rows=num_rows_removed)
 
 def split_data():
-    if request.method == 'POST':
-        request_dict = request.form.to_dict()
-        training_ratio = int(request_dict['trainingRatioRange'])/100
-        train_data_size = generator.split_data(training_ratio)
-        return render_template('info/splitting_summary.html', num_rows_train=train_data_size[0])
+   if request.method == 'POST':
+      request_dict = request.form.to_dict()
+      training_ratio = int(request_dict['trainingRatioRange'])/100
+      train_data_size = generator.split_data(training_ratio)
+      return render_template('info/splitting_summary.html', num_rows_train=train_data_size[0])
 
-    return render_template('actions/select_training_ratio_value.html')
+   return render_template('actions/select_training_ratio_value.html')
 
 def get_input_labels():
-    if request.method == 'POST':
-        request_dict = request.form.to_dict(flat=False)
-        generator.drop_x(request_dict['drop_labels'])
-        return render_template('actions/actions.html')
+   if request.method == 'POST':
+      request_dict = request.form.to_dict(flat=False)
+      generator.drop_x(request_dict['drop_labels'])
+      return render_template('actions/actions.html')
 
-    keys = generator.get_labels()
-    return render_template('actions/select_input_values.html', labels=keys)
+   keys = generator.get_labels()
+   return render_template('actions/select_input_values.html', labels=keys)
 
 def get_data_labels():
-    if request.method == 'POST':
-        request_dict = request.form.to_dict()
-        generator.select_y(request_dict['label'])
-        return redirect('/input_labels')
+   if request.method == 'POST':
+      request_dict = request.form.to_dict()
+      generator.select_y(request_dict['label'])
+      return redirect('/input_labels')
 
-    keys = generator.get_labels()
-    return render_template('actions/select_output_value.html', labels=keys)
-    # return render_template('labels.html', labels=keys)
+   keys = generator.get_labels()
+   return render_template('actions/select_output_value.html', labels=keys)
+   # return render_template('labels.html', labels=keys)
 
 def upload_file():
-    if request.method == 'POST':
-        # check if the post request has the file part
-        if 'file' not in request.files:
-            flash('No file part')
-            return redirect(request.url)
+   if request.method == 'POST':
+      # check if the post request has the file part
+      if 'file' not in request.files:
+         flash('No file part')
+         return redirect(request.url)
 
-        file = request.files['file']
-        # If the user does not select a file, the browser submits an
-        # empty file without a filename.
-        if file.filename == '':
-            flash('No selected file')
-            return redirect(request.url)
+      file = request.files['file']
+      # If the user does not select a file, the browser submits an
+      # empty file without a filename.
+      if file.filename == '':
+         flash('No selected file')
+         return redirect(request.url)
 
-        if file and allowed_file(file.filename):
-            filename = secure_filename(file.filename)
-            file.save(os.path.join(current_app.config['UPLOAD_FOLDER'], filename))
-            # return redirect(url_for('download_file', name=filename))
-            print(g)
+      if file and allowed_file(file.filename):
+         filename = secure_filename(file.filename)
+         file.save(os.path.join(current_app.config['UPLOAD_FOLDER'], filename))
+         # return redirect(url_for('download_file', name=filename))
+         print(g)
 
-            with current_app.app_context():
-                generator.load_data(current_app.config['UPLOAD_FOLDER']+'/' + filename)
+         with current_app.app_context():
+            generator.load_data(current_app.config['UPLOAD_FOLDER']+'/' + filename)
 
-            return render_template('actions/actions.html')
+         return render_template('actions/actions.html')
 
-    return render_template('actions/upload_data.html')
+   return render_template('actions/upload_data.html')
 
 def next_actions():
-    return render_template('actions/actions.html')
+   return render_template('actions/actions.html')

--- a/flask_app/flask_main.py
+++ b/flask_app/flask_main.py
@@ -1,14 +1,4 @@
-import os
-
-from flask import g
 from flask import Flask
-from flask import render_template
-from flask import request, redirect, flash
-from werkzeug.utils import secure_filename
-
-from application import code_generator
-from pandas_code.mapping import template_mapping
-from pandas_code.parse_template import parse_template
 
 from flask_app.api.config import UPLOAD_FOLDER
 import flask_app.api.views as views
@@ -18,7 +8,6 @@ def create_app():
 
    app = Flask(__name__, template_folder='templates')
    app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
-   generator = code_generator.CodeGenerator(template_mapping, parse_template)
 
    app.add_url_rule('/', view_func=views.welcome, methods=['GET'])
    app.add_url_rule('/download', view_func=views.download_code, methods=['GET'])

--- a/flask_app/flask_main.py
+++ b/flask_app/flask_main.py
@@ -10,10 +10,9 @@ from application import code_generator
 from pandas_code.mapping import template_mapping
 from pandas_code.parse_template import parse_template
 
+from flask_app.api.config import UPLOAD_FOLDER
+import flask_app.api.views as views
 
-ALLOWED_EXTENSIONS = {'csv'}
-
-UPLOAD_FOLDER='data/'
 
 def create_app():
 
@@ -21,89 +20,15 @@ def create_app():
    app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
    generator = code_generator.CodeGenerator(template_mapping, parse_template)
 
-   @app.route('/')
-   def welcome():
-      return render_template('home.html')
-
-   def allowed_file(filename):
-      return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
-
-   @app.route('/download', methods=['GET'])
-   def download_code():
-      code = generator.download_code()
-      return render_template('info/code.html', text=code)
-
-   @app.route('/describe', methods=['GET'])
-   def describe_data():
-      description = generator.describe_data()
-      return render_template('info/description.html',table=description.to_html())
-
-   @app.route('/clean', methods=['GET'])
-   def clean_data():
-      original_data_size = generator.get_data().shape
-      cleaned_data_size = generator.clean_data()
-      num_rows_removed = original_data_size[0]-cleaned_data_size[0]
-      return render_template('info/cleaning_summary.html', removed_rows=num_rows_removed)
-
-   @app.route('/split', methods=['GET', 'POST'])
-   def split_data():
-      if request.method == 'POST':
-         request_dict = request.form.to_dict()
-         training_ratio = int(request_dict['trainingRatioRange'])/100
-         train_data_size = generator.split_data(training_ratio)
-         return render_template('info/splitting_summary.html', num_rows_train=train_data_size[0])
-
-      return render_template('actions/select_training_ratio_value.html')
-
-   @app.route('/input_labels', methods=['GET', 'POST'])
-   def get_input_labels():
-      if request.method == 'POST':
-         request_dict = request.form.to_dict(flat=False)
-         generator.drop_x(request_dict['drop_labels'])
-         return render_template('actions/actions.html')
-
-      keys = generator.get_labels()
-      return render_template('actions/select_input_values.html', labels=keys)
-
-   @app.route('/labels', methods=['GET', 'POST'])
-   def get_data_labels():
-      if request.method == 'POST':
-         request_dict = request.form.to_dict()
-         generator.select_y(request_dict['label'])
-         return redirect('/input_labels')
-
-      keys = generator.get_labels()
-      return render_template('actions/select_output_value.html', labels=keys)
-   #   return render_template('labels.html', labels=keys)
-
-   @app.route('/data', methods=['GET', 'POST'])
-   def upload_file():
-      if request.method == 'POST':
-         # check if the post request has the file part
-         if 'file' not in request.files:
-            flash('No file part')
-            return redirect(request.url)
-
-         file = request.files['file']
-         # If the user does not select a file, the browser submits an
-         # empty file without a filename.
-         if file.filename == '':
-            flash('No selected file')
-            return redirect(request.url)
-         if file and allowed_file(file.filename):
-            filename = secure_filename(file.filename)
-            file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
-            # return redirect(url_for('download_file', name=filename))
-            print(g)
-            with app.app_context():
-               generator.load_data(app.config['UPLOAD_FOLDER']+'/'+filename)
-            return render_template('actions/actions.html')
-
-      return render_template('actions/upload_data.html')
-
-   @app.route('/actions')
-   def next_actions():
-      return render_template('actions/actions.html')
+   app.add_url_rule('/', view_func=views.welcome, methods=['GET'])
+   app.add_url_rule('/download', view_func=views.download_code, methods=['GET'])
+   app.add_url_rule('/describe', view_func=views.describe_data, methods=['GET'])
+   app.add_url_rule('/clean', view_func=views.clean_data, methods=['GET'])
+   app.add_url_rule('/split', view_func=views.split_data, methods=['GET', 'POST'])
+   app.add_url_rule('/input_labels', view_func=views.get_input_labels, methods=['GET', 'POST'])
+   app.add_url_rule('/labels', view_func=views.get_data_labels, methods=['GET', 'POST'])
+   app.add_url_rule('/data', view_func=views.upload_file, methods=['GET', 'POST'])
+   app.add_url_rule('/actions', view_func=views.next_actions, methods=['GET'])
 
    return app
 


### PR DESCRIPTION
This PR implements a centralized URL map separated from the Flask app factory.

To better organize the new code, a new `flask_app/api/` directory was created, with routes added to a `views.py` file. Because the views require code originally implemented within the app factory scope, some methods and variables were separated into a few dedicated files as well:

- The `ALLOWED_EXTENSIONS` and `UPLOAD_FOLDER` were moved to a `config.py` file.
- The `allowed_file` function was moved to an `utils.py` file.
- The `CodeGenerator` instance was moved to a `generator.py` file. Because this appears to be the entrypoint to the code generator application, a dedicated file seemed a good approach.

Pytest suites have passed and manually interacting with the Flask app did not indicate abnormal behavior.
