### PR TITLE
Updating Requirements file for missing SKLEARN import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ requests
 python-dotenv
 Authlib
 pylint
-sklearn
+scikit-learn
 numpy


### PR DESCRIPTION
It will help to resolve missing SKLEARN import which can't be installed properly using the old sklearn line in requirements.txt file.